### PR TITLE
Remove dependencies on Rodin and Event-B EMF plugins

### DIFF
--- a/ac.soton.emf.translator.feature/feature.properties
+++ b/ac.soton.emf.translator.feature/feature.properties
@@ -22,8 +22,10 @@ featureDescription=\
 This feature provides a framework for creating EMF model-to-model translators.\n\
 ------------------------------------------------------------------------------\n\
 Release history:\n\
-2.1.2.qualifier\n\
- - feature renamed from ac.soton.emf.utilities (version numbering inherited)
+3.0.0.qualifier\n\
+ - Handler no longer converts rodin elements to Event-B EMF. A new method getEObject can be overridden by clients to do this\n\
+        (this removes dependencies on Rodin and Event-B EMF plugins)\n\
+ - feature renamed from ac.soton.emf.utilities (version numbering inherited)\n\
  - log exceptions thrown by translator command\n\
 2.1.1.release\n\
  - add release history for 2.1.0 to bui\n\

--- a/ac.soton.emf.translator.feature/feature.properties
+++ b/ac.soton.emf.translator.feature/feature.properties
@@ -23,7 +23,7 @@ This feature provides a framework for creating EMF model-to-model translators.\n
 ------------------------------------------------------------------------------\n\
 Release history:\n\
 3.0.0.qualifier\n\
- - Handler no longer converts rodin elements to Event-B EMF. A new method getEObject can be overridden by clients to do this\n\
+ - Handler no longer converts Rodin elements to Event-B EMF. A new method getEObject can be overridden by clients to do this\n\
         (this removes dependencies on Rodin and Event-B EMF plugins)\n\
  - feature renamed from ac.soton.emf.utilities (version numbering inherited)\n\
  - log exceptions thrown by translator command\n\

--- a/ac.soton.emf.translator.feature/feature.xml
+++ b/ac.soton.emf.translator.feature/feature.xml
@@ -2,7 +2,7 @@
 <feature
       id="ac.soton.emf.translator.feature"
       label="%featureName"
-      version="2.1.2.qualifier"
+      version="3.0.0.qualifier"
       provider-name="%featureVendor"
       license-feature="org.rodinp.license"
       license-feature-version="1.0.0.release">

--- a/ac.soton.emf.translator/META-INF/MANIFEST.MF
+++ b/ac.soton.emf.translator/META-INF/MANIFEST.MF
@@ -2,7 +2,7 @@ Manifest-Version: 1.0
 Bundle-ManifestVersion: 2
 Bundle-Name: %Bundle-Name
 Bundle-SymbolicName: ac.soton.emf.translator;singleton:=true
-Bundle-Version: 2.1.1.qualifier
+Bundle-Version: 3.0.0.qualifier
 Bundle-Activator: ac.soton.emf.translator.Activator
 Bundle-Vendor: %Bundle-Vendor
 Require-Bundle: org.eclipse.core.runtime;bundle-version="[3.10.0,4.0.0)",

--- a/ac.soton.emf.translator/META-INF/MANIFEST.MF
+++ b/ac.soton.emf.translator/META-INF/MANIFEST.MF
@@ -9,10 +9,7 @@ Require-Bundle: org.eclipse.core.runtime;bundle-version="[3.10.0,4.0.0)",
  org.eclipse.ui;bundle-version="[3.7.0,4.0.0)",
  org.eclipse.ui.ide;bundle-version="[3.7.0,4.0.0)",
  org.eclipse.emf.workspace;bundle-version="[1.5.0,2.0.0)",
- org.eclipse.core.resources;bundle-version="[3.9.1,4.0.0)",
- org.eventb.emf.persistence;bundle-version="[3.5.0,4.0.0)",
- org.rodinp.core;bundle-version="[1.7.0,2.0.0)",
- org.eventb.emf.core;bundle-version="[4.2.1,5.0.0)"
+ org.eclipse.core.resources;bundle-version="[3.9.1,4.0.0)"
 Bundle-RequiredExecutionEnvironment: JavaSE-1.7
 Bundle-ActivationPolicy: lazy
 Export-Package: ac.soton.emf.translator,

--- a/ac.soton.emf.translator/src/ac/soton/emf/translator/handler/TranslateHandler.java
+++ b/ac.soton.emf.translator/src/ac/soton/emf/translator/handler/TranslateHandler.java
@@ -27,12 +27,10 @@ import org.eclipse.jface.dialogs.MessageDialog;
 import org.eclipse.jface.dialogs.ProgressMonitorDialog;
 import org.eclipse.jface.operation.IRunnableWithProgress;
 import org.eclipse.jface.viewers.ISelection;
-import org.eclipse.jface.viewers.TreeSelection;
+import org.eclipse.jface.viewers.StructuredSelection;
 import org.eclipse.swt.widgets.Shell;
 import org.eclipse.ui.IWorkbenchWindow;
 import org.eclipse.ui.handlers.HandlerUtil;
-import org.eventb.emf.persistence.EMFRodinDB;
-import org.rodinp.core.IInternalElement;
 
 import ac.soton.emf.translator.Activator;
 import ac.soton.emf.translator.TranslatorFactory;
@@ -52,24 +50,12 @@ public class TranslateHandler extends AbstractHandler {
 	 */
 	@Override
 	public final Object execute(ExecutionEvent event) throws ExecutionException {
-		final EObject sourceElement; // = null;
+		final EObject sourceElement;
 		ISelection selection = HandlerUtil.getCurrentSelection(event);
-		if (selection instanceof TreeSelection){
-			Object obj = ((TreeSelection)selection).getFirstElement();
-			if (obj instanceof EObject){
-				sourceElement = (EObject)obj;
-			}else if (obj instanceof IInternalElement){
-				sourceElement = new EMFRodinDB().loadEventBComponent((IInternalElement)obj) ;
-			}else if (obj instanceof IAdaptable) {
-				Object adaptedObj = ((IAdaptable) obj).getAdapter(EObject.class);
-				if (adaptedObj instanceof EObject){
-					sourceElement = (EObject) adaptedObj; 
-				} else return null;
-			}else if (obj instanceof Resource){
-				sourceElement = ((Resource)obj).getContents().get(0);
-			}else return null;
-		} else return null;
-		
+		if (selection instanceof StructuredSelection && !((StructuredSelection)selection).isEmpty()){
+			Object obj = ((StructuredSelection)selection).getFirstElement();
+			sourceElement = getEObject(obj);
+		} else sourceElement = null;
 		if (sourceElement==null) return null;
 		
 		IWorkbenchWindow activeWorkbenchWindow = HandlerUtil.getActiveWorkbenchWindow(event);
@@ -113,6 +99,32 @@ public class TranslateHandler extends AbstractHandler {
 				MessageDialog.openError(shell, Messages.TRANSLATOR_MSG_07, e.getMessage());
 			}
 		return null;
+	}
+
+
+	/**
+	 * From the selected object, get an EObject that can be translated.
+	 * The default code handles 
+	 * 	selection is an EObject (return object castr to EObject)
+	 * 	selection is an IAdaptable (return adapted EObject)
+	 *  selection is an EMF Resource (return contained EObject)
+	 * This can be overridden to handle other cases
+	 * @param obj
+	 * @return corresponding EObject to be translated
+	 */
+	protected EObject getEObject(Object obj) {
+		final EObject sourceElement;
+		if (obj instanceof EObject){
+			sourceElement = (EObject)obj;
+		}else if (obj instanceof IAdaptable) {
+			Object adaptedObj = ((IAdaptable) obj).getAdapter(EObject.class);
+			if (adaptedObj instanceof EObject){
+				sourceElement = (EObject) adaptedObj; 
+			} else sourceElement = null;
+		}else if (obj instanceof Resource){
+			sourceElement = ((Resource)obj).getContents().get(0);
+		}else sourceElement = null;
+		return sourceElement;
 	}
 
 	

--- a/ac.soton.emf.translator/src/ac/soton/emf/translator/handler/TranslateHandler.java
+++ b/ac.soton.emf.translator/src/ac/soton/emf/translator/handler/TranslateHandler.java
@@ -27,7 +27,7 @@ import org.eclipse.jface.dialogs.MessageDialog;
 import org.eclipse.jface.dialogs.ProgressMonitorDialog;
 import org.eclipse.jface.operation.IRunnableWithProgress;
 import org.eclipse.jface.viewers.ISelection;
-import org.eclipse.jface.viewers.StructuredSelection;
+import org.eclipse.jface.viewers.IStructuredSelection;
 import org.eclipse.swt.widgets.Shell;
 import org.eclipse.ui.IWorkbenchWindow;
 import org.eclipse.ui.handlers.HandlerUtil;
@@ -52,8 +52,8 @@ public class TranslateHandler extends AbstractHandler {
 	public final Object execute(ExecutionEvent event) throws ExecutionException {
 		final EObject sourceElement;
 		ISelection selection = HandlerUtil.getCurrentSelection(event);
-		if (selection instanceof StructuredSelection && !((StructuredSelection)selection).isEmpty()){
-			Object obj = ((StructuredSelection)selection).getFirstElement();
+		if (selection instanceof IStructuredSelection && !selection.isEmpty()){
+			Object obj = ((IStructuredSelection)selection).getFirstElement();
 			sourceElement = getEObject(obj);
 		} else sourceElement = null;
 		if (sourceElement==null) return null;


### PR DESCRIPTION
This is an EMF-generic translator but had dependencies on Rodin and Event-B EMF in order to obtain an EObject from the selected Rodin element in the command handler. To avoid this dependency the provided handler no longer supports this functionality. A method has been extracted to do the conversion of a selected object into an EObject and clients can override this method to add non-standard conversions.