### PR TITLE
allow non-late rules to fire late in case they depend on late rules

### DIFF
--- a/ac.soton.emf.translator/src/ac/soton/emf/translator/impl/Translator.java
+++ b/ac.soton.emf.translator/src/ac/soton/emf/translator/impl/Translator.java
@@ -367,7 +367,7 @@ public class Translator {
 				List<IRule> firedRules = new ArrayList<IRule>();
 				for (IRule rule : deferredRules.get(sourceElement)){
 					if (rule != null && rule.enabled(sourceElement)) {
-						if (late==rule.fireLate() && rule.dependenciesOK(sourceElement, translatedElements)){
+						if ((late || !rule.fireLate()) && rule.dependenciesOK(sourceElement, translatedElements)){
 							translatedElements.addAll(rule.fire(sourceElement, translatedElements));
 							firedRules.add(rule);
 						}


### PR DESCRIPTION
discovered a scenario where a late rule holds up a non-late rule - which then could not fire because it was too late!

I guess it is sensible to allow non-late rules to fire late in this case.