### PR TITLE
re-structured translate handler

### DIFF
--- a/ac.soton.emf.translator/src/ac/soton/emf/translator/TranslatorFactory.java
+++ b/ac.soton.emf.translator/src/ac/soton/emf/translator/TranslatorFactory.java
@@ -1,5 +1,5 @@
 /*******************************************************************************
- *  Copyright (c) 2015-2017 University of Southampton.
+ *  Copyright (c) 2015-2018 University of Southampton.
  *  All rights reserved. This program and the accompanying materials
  *  are made available under the terms of the Eclipse Public License v1.0
  *  which accompanies this distribution, and is available at
@@ -164,6 +164,7 @@ public class TranslatorFactory {
 	 * @param commandId
 	 * @param monitor 
 	 * @throws ExecutionException 
+	 * @since 3.0
 	 */
 	public IStatus translate(TransactionalEditingDomain editingDomain, EObject sourceElement, String commandId, IProgressMonitor monitor) throws ExecutionException {
 		IStatus status = null;
@@ -207,6 +208,7 @@ public class TranslatorFactory {
 	 * @param commandId
 	 * @param monitor 
 	 * @throws ExecutionException 
+	 * @since 3.0
 	 */
 	
 	public IStatus untranslate(TransactionalEditingDomain editingDomain, EObject sourceElement, String commandId, IProgressMonitor monitor) throws ExecutionException {

--- a/ac.soton.emf.translator/src/ac/soton/emf/translator/configuration/IAdapter.java
+++ b/ac.soton.emf.translator/src/ac/soton/emf/translator/configuration/IAdapter.java
@@ -1,5 +1,5 @@
 /*******************************************************************************
- *  Copyright (c) 2015 University of Southampton.
+ *  Copyright (c) 2015-2018 University of Southampton.
  *  All rights reserved. This program and the accompanying materials
  *  are made available under the terms of the Eclipse Public License v1.0
  *  which accompanies this distribution, and is available at
@@ -34,6 +34,7 @@ public interface IAdapter {
 	 * returns true if the translation descriptor describes a new root level element
 	 * @param translationDescriptor
 	 * @return
+	 * @since 3.0
 	 */
 	boolean isRoot(TranslationDescriptor translationDescriptor);
 	
@@ -60,6 +61,7 @@ public interface IAdapter {
 	 * @param editingDomain
 	 * @param sourceElement
 	 * @return list of affected Resources
+	 * @since 3.0
 	 */
 	Collection<Resource> getAffectedResources(TransactionalEditingDomain editingDomain, EObject sourceElement) throws IOException ;
 		


### PR DESCRIPTION
re-structured translate handler as discussed. 
query user if outstanding changes (options: continue to save before translate, or cancel)
pre-process before validation. 
remove 'enable' methods and replace with OK status of previous step.
only save if all steps give ok status otherwise discard all changes.
manage the status displaying feedback if not OK/Cancel